### PR TITLE
Fix bug that caused the beam to be included in results

### DIFF
--- a/inspector.py
+++ b/inspector.py
@@ -82,7 +82,9 @@ def printAncestors(particle, ancestors=[], verbose=True):
         if abs(mum.pdgId())<8 or \
            abs(mum.pdgId())==21 or \
            abs(mum.pdgId()) in diquarks or\
-           abs(mum.pdgId()) in excitedBs: continue
+           abs(mum.pdgId()) in excitedBs or\
+           abs(mum.eta()) > 1000: # beam protons
+            continue
         # don't count B oscillations
         if mum.pdgId() == -particle.pdgId() and abs(particle.pdgId()) in [511, 531]:
             continue 
@@ -256,6 +258,7 @@ for i, event in enumerate(events):
             ids.ancestors = ancestorsds
 
         if len(ids.ancestors)==0 or len(imu.ancestors)==0: continue
+        if ids in imu.ancestors: continue
         if (imu.charge()*ids.charge() > 0): continue #same charge, cannot be a single B0
 
         if ids.ancestors[-1] != imu.ancestors[-1]: continue


### PR DESCRIPTION
* Remove beam proton from possible ancestors using an eta cut
* Check for the Dst being an ancestor of the muon (possible if the generator considers the K as decaying into muons)